### PR TITLE
Change the 'Add child page' link on publications to add a publication page, not a book page.

### DIFF
--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -5,6 +5,8 @@
  * Module file for the LocalGov Publications module.
  */
 
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
 use Drupal\user\Entity\Role;
 
 /**
@@ -36,6 +38,13 @@ function localgov_publications_modules_installed($modules, $is_syncing) {
 }
 
 /**
+ * Is the given type one of the publication node types?
+ */
+function localgov_publications_is_publication_type(string $type): bool {
+  return $type === 'localgov_publication_page' || $type === 'publication_landing_page';
+}
+
+/**
  * Implements hook_theme_suggestions_HOOK().
  */
 function localgov_publications_theme_suggestions_book_navigation(array $variables) {
@@ -43,11 +52,24 @@ function localgov_publications_theme_suggestions_book_navigation(array $variable
 
   // Only add suggestion on publication pages and publication landing pages.
   $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node->getType() === 'localgov_publication_page' ||
-      $node->getType() === 'publication_landing_page') {
+  if (localgov_publications_is_publication_type($node->getType())) {
     $original = $variables['theme_hook_original'] . '__';
     $suggestions[] = $original . 'publication';
   }
 
   return $suggestions;
+}
+
+/**
+ * Implements hook_node_links_alter().
+ *
+ * If book module has added the "Add child page" link, and we're on a
+ * publication type page, alter the link, so it creates a
+ * localgov_publication_page, instead of the default book type.
+ */
+function localgov_publications_node_links_alter(array &$links, NodeInterface $node, array &$context) {
+
+  if (localgov_publications_is_publication_type($node->getType()) && !empty($links['book']['#links']['book_add_child'])) {
+    $links['book']['#links']['book_add_child']['url'] = Url::fromRoute('node.add', ['node_type' => 'localgov_publication_page'], ['query' => ['parent' => $node->id()]]);
+  }
 }

--- a/tests/src/Functional/ChildLinkTest.php
+++ b/tests/src/Functional/ChildLinkTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\Tests\localgov_publications\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Functional tests for our link modifications.
+ */
+class ChildLinkTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'localgov_base';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'localgov';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_publications',
+  ];
+
+  /**
+   * Test the 'Add child page' link on a publication goes to the right type.
+   */
+  public function testAddChildPageLink() {
+
+    $adminUser = $this->drupalCreateUser([], NULL, TRUE);
+
+    $node = $this->createNode([
+      'type' => 'localgov_publication_page',
+      'title' => 'Test publication page',
+      'body' => [
+        'summary' => '<p>Content</p>',
+        'value' => '<p>Content</p>',
+        'format' => 'wysiwyg',
+      ],
+      'book' => [
+        'bid' => 'new',
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->drupalLogin($adminUser);
+    $this->drupalGet('/node/' . $node->id());
+    $this->assertSession()->responseContains('<a href="/node/add/localgov_publication_page?parent=1">Add child page</a>');
+  }
+
+}


### PR DESCRIPTION
Fixes #34 