### PR TITLE
Move links below content on publications page. Hide content label.

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_publication_page.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_publication_page.default.yml
@@ -22,21 +22,21 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 101
+    weight: 0
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 4
     region: content
   localgov_page_content:
     type: entity_reference_revisions_entity_view
-    label: above
+    label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 104
+    weight: 3
     region: content
   localgov_published_date:
     type: datetime_default
@@ -45,7 +45,7 @@ content:
       timezone_override: ''
       format_type: medium
     third_party_settings: {  }
-    weight: 102
+    weight: 1
     region: content
   localgov_updated_date:
     type: datetime_default
@@ -54,6 +54,6 @@ content:
       timezone_override: ''
       format_type: medium
     third_party_settings: {  }
-    weight: 103
+    weight: 2
     region: content
 hidden: {  }


### PR DESCRIPTION
Fixes #48.

Before:
<img width="1231" alt="before" src="https://user-images.githubusercontent.com/326243/228202190-92ea7d39-f5cf-46c0-add1-657bcdfb40fe.png">

After:
<img width="1232" alt="after" src="https://user-images.githubusercontent.com/326243/228202205-aa5925a7-738c-4cb3-8f5f-aefc75711a6d.png">
