### PR TITLE
Fixed bug where HTML entites in titles found by the ToC block are double escaped.

### DIFF
--- a/src/Service/HeadingFinder.php
+++ b/src/Service/HeadingFinder.php
@@ -21,12 +21,13 @@ class HeadingFinder implements HeadingFinderInterface {
     // Look for headings in the text.
     if (preg_match_all('#<h2([^>]+)>([^<]+)</h2>#', $markup, $matches)) {
 
-      // Format the results into $headings
-      // under the 'attributes' and 'text' keys.
+      // Format the results into $headings under the 'attributes' and 'text'
+      // keys. As we scanned rendered and escaped markup, we'll need to decode
+      // the title to avoid double escaping.
       foreach ($matches[1] as $key => $value) {
         $headings[] = [
           'attributes' => $value,
-          'text' => $matches[2][$key],
+          'text' => html_entity_decode($matches[2][$key]),
         ];
       }
     }

--- a/tests/src/Unit/HeadingFinderTest.php
+++ b/tests/src/Unit/HeadingFinderTest.php
@@ -51,6 +51,13 @@ class HeadingFinderTest extends UnitTestCase {
       'markup' => '<p>Content 1.</p><p>Content 2.</p>',
       'expectedLinks' => [],
     ];
+    // Check HTML entities are handled correctly.
+    yield [
+      'markup' => '<h2 id="hammersmith-fulham">Hammersmith &amp; Fulham</h2><p>Hammersmith &amp; Fulham is a London borough in West London.</p>',
+      'expectedLinks' => [
+        new Link('Hammersmith & Fulham', Url::fromUri('base:<none>', ['fragment' => 'hammersmith-fulham'])),
+      ],
+    ];
   }
 
   /**


### PR DESCRIPTION
Fixes #50 