### PR TITLE
Removed version constraint on localgov_paragraphs from info file.

### DIFF
--- a/localgov_publications.info.yml
+++ b/localgov_publications.info.yml
@@ -12,5 +12,5 @@ dependencies:
   - footnotes:footnotes
   - pathauto:pathauto
   - localgov_media:localgov_media
-  - localgov_paragraphs:localgov_paragraphs (>=2.3.2)
+  - localgov_paragraphs:localgov_paragraphs
   - localgov_services:localgov_services


### PR DESCRIPTION
As localgov_paragraphs is installed via composer, not a d.o package, info file constraints can't be used.