### PR TITLE
Don't show the publication navigation block on single page publications.

### DIFF
--- a/src/Plugin/Block/PublicationNavigationBlock.php
+++ b/src/Plugin/Block/PublicationNavigationBlock.php
@@ -81,6 +81,15 @@ class PublicationNavigationBlock extends BlockBase implements ContainerFactoryPl
 
     if (!empty($node->book['bid'])) {
       $tree = $this->bookManager->bookTreeAllData($node->book['bid'], $node->book);
+
+      // If the top level doesn't have any child pages, (IE this is a single
+      // page publication) don't show the menu block, as there isn't anything
+      // else to navigate to.
+      $top = reset($tree);
+      if (empty($top['below'])) {
+        return [];
+      }
+
       $output = $this->bookManager->bookTreeOutput($tree);
       if (!empty($output)) {
         $this->node = $node;


### PR DESCRIPTION
Fix for #129 