### PR TITLE
Fix/1.x/update publication type name

### DIFF
--- a/localgov_publications.install
+++ b/localgov_publications.install
@@ -11,7 +11,7 @@
 function localgov_publications_install() {
   $config = \Drupal::configFactory()->getEditable('book.settings');
   $allowed_types = $config->get('allowed_types');
-  $allowed_types[] = 'publication';
+  $allowed_types[] = 'localgov_publication_page';
   $config->set('allowed_types', $allowed_types);
   $config->save();
   $path_auto_config = \Drupal::configFactory()->getEditable('pathauto.settings');


### PR DESCRIPTION
We used to have a type called 'publication', but this got renamed to 'localgov_publication_page'. I just spotted an instance of 'publication' that got missed when renaming.