### PR TITLE
Update Heading Tags filter

### DIFF
--- a/src/Plugin/Filter/HeadingIdFilter.php
+++ b/src/Plugin/Filter/HeadingIdFilter.php
@@ -88,7 +88,7 @@ class HeadingIdFilter extends FilterBase implements ContainerFactoryPluginInterf
     $output = $text;
     $html_dom = Html::load($text);
     $xpath = new \DOMXPath($html_dom);
-    $heading_tags = '//h2|//h3|//h4|//h5|//h6';
+    $heading_tags = '//body/h2|//body/h3|//body/h4|//body/h5|//body/h6';
     $keep_existing_ids = $this->settings['keep_existing_ids'] ?? FALSE;
 
     // Apply attribute restrictions to headings.


### PR DESCRIPTION
The "on the page" contents wasn't working as expected as the IDs given to the Headings on the page were being appended with --n (n in most cases was 2)

The patch suggested on https://www.drupal.org/project/auto_heading_ids/issues/3025156 which is for the module where the filter code was coied from looks like it resolves the issue here 