### PR TITLE
Clear all caches after uninstall Book node 

### DIFF
--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -273,8 +273,8 @@ function localgov_publications_modules_installed($modules, $is_syncing) {
     unset($fieldMap['body']['bundles']['book']);
     $kvStore->set('node', $fieldMap);
 
-    // Clear the cache where the full map is stored.
-    \Drupal::cache('discovery')->delete('entity_field_map');
+    // Clear all caches to ensure there are no references to the Book node left.
+    drupal_flush_all_caches();
   }
 }
 


### PR DESCRIPTION
Fixes error thrown when including the Publications module with the Demo content module.

See #171 and https://github.com/localgovdrupal/localgov_demo/pull/124#issuecomment-2166010730

Fixes #171