### PR TITLE
Add description to info.yml

### DIFF
--- a/localgov_publications.info.yml
+++ b/localgov_publications.info.yml
@@ -1,6 +1,6 @@
 name: LocalGov Publications
 type: module
-description: Provides additional functionality for the site.
+description: HTML publications for the LocalGovDrupal distribution.
 package: LocalGov Drupal
 core_version_requirement: ^9 || ^10
 


### PR DESCRIPTION
Fix #182 



<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Match module description in info.yml with same as composer.json.

## How to test

Go to extend and search for Localgov Publications and the description should be updated.

## How can we measure success?

Does this make more sense for what the module does

## Have we considered potential risks?

n/a

## Images

n/a

## Accessibility

n/a