### PR TITLE
Limit localgov_publications 1.x to Drupal 10, as that includes book in core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+        "drupal/core": "^10.0.0",
         "localgovdrupal/localgov_core": ">=2.1.10",
         "localgovdrupal/localgov_paragraphs": ">=2.4.0"
     },


### PR DESCRIPTION
This alters composer.json to say this release is only compatible with Drupal 10.