### PR TITLE
Use contrib book instead of core book module. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+        "drupal/book": "^1.0.0",
         "localgovdrupal/localgov_core": ">=2.1.10",
         "localgovdrupal/localgov_paragraphs": ">=2.4.0"
     },

--- a/localgov_publications.info.yml
+++ b/localgov_publications.info.yml
@@ -2,10 +2,10 @@ name: LocalGov Publications
 type: module
 description: HTML publications for the LocalGovDrupal distribution.
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ">=9"
 
 dependencies:
-  - drupal:book
+  - book:book
   - drupal:menu_ui
   - drupal:views
   - pathauto:pathauto

--- a/localgov_publications.info.yml
+++ b/localgov_publications.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Publications
 type: module
 description: HTML publications for the LocalGovDrupal distribution.
 package: LocalGov Drupal
-core_version_requirement: ">=9"
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - book:book


### PR DESCRIPTION
Also relax core_version_requirement so we can run on D11.

Fix for #180 