### PR TITLE
Fix/1.x/148 view permissions

### DIFF
--- a/config/install/views.view.publications.yml
+++ b/config/install/views.view.publications.yml
@@ -271,7 +271,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'access content'
+          perm: 'access publication views'
       cache:
         type: tag
         options: {  }

--- a/localgov_publications.install
+++ b/localgov_publications.install
@@ -89,3 +89,31 @@ function localgov_publications_update_10001() {
   }
   \Drupal::cache('discovery')->delete('entity_field_map');
 }
+
+/**
+ * Expanding Publications permissions.
+ *
+ * Grant 'access publication views' permission to Editor and apply as an access
+ * condition to the publication view.
+ */
+function localgov_publications_update_10002() {
+
+  // Make sure Editors have the new View permission.
+  $role = Role::load('localgov_editor');
+  $role->grantPermission('access publication views');
+  $role->save();
+
+  // Check if the view needs updating to use new permission.
+  $config_factory = Drupal::service('config.factory');
+  if ($editable = $config_factory->getEditable('views.view.publications')) {
+    $display = $editable->get('display');
+    if (isset($display['default']['display_options']['access'])) {
+      $access = $display['default']['display_options']['access'];
+      // Only update if the defaults haven't been changed.
+      if ($access['type'] == 'perm' && $access['options']['perm'] == 'access content') {
+        $display['default']['display_options']['access']['options']['perm'] = 'access publication views';
+        $editable->set('display', $display)->save();
+      }
+    }
+  }
+}

--- a/localgov_publications.install
+++ b/localgov_publications.install
@@ -96,24 +96,25 @@ function localgov_publications_update_10001() {
  * Grant 'access publication views' permission to Editor and apply as an access
  * condition to the publication view.
  */
-function localgov_publications_update_10002() {
+function localgov_publications_update_10002($is_syncing) {
+  if (!$is_syncing) {
+    // Make sure Editors have the new View permission.
+    $entity_type_manager = Drupal::service('entity_type.manager');
+    $role = $entity_type_manager->getStorage('user_role')->load('localgov_editor');
+    $role->grantPermission('access publication views');
+    $role->save();
 
-  // Make sure Editors have the new View permission.
-  $entity_type_manager = Drupal::service('entity_type.manager');
-  $role = $entity_type_manager->getStorage('user_role')->load('localgov_editor');
-  $role->grantPermission('access publication views');
-  $role->save();
-
-  // Check if the view needs updating to use new permission.
-  $config_factory = Drupal::service('config.factory');
-  if ($editable = $config_factory->getEditable('views.view.publications')) {
-    $display = $editable->get('display');
-    if (isset($display['default']['display_options']['access'])) {
-      $access = $display['default']['display_options']['access'];
-      // Only update if the defaults haven't been changed.
-      if ($access['type'] == 'perm' && $access['options']['perm'] == 'access content') {
-        $display['default']['display_options']['access']['options']['perm'] = 'access publication views';
-        $editable->set('display', $display)->save();
+    // Check if the view needs updating to use new permission.
+    $config_factory = Drupal::service('config.factory');
+    if ($editable = $config_factory->getEditable('views.view.publications')) {
+      $display = $editable->get('display');
+      if (isset($display['default']['display_options']['access'])) {
+        $access = $display['default']['display_options']['access'];
+        // Only update if the defaults haven't been changed.
+        if ($access['type'] == 'perm' && $access['options']['perm'] == 'access content') {
+          $display['default']['display_options']['access']['options']['perm'] = 'access publication views';
+          $editable->set('display', $display)->save();
+        }
       }
     }
   }

--- a/localgov_publications.install
+++ b/localgov_publications.install
@@ -99,7 +99,8 @@ function localgov_publications_update_10001() {
 function localgov_publications_update_10002() {
 
   // Make sure Editors have the new View permission.
-  $role = Role::load('localgov_editor');
+  $entity_type_manager = Drupal::service('entity_type.manager');
+  $role = $entity_type_manager->getStorage('user_role')->load('localgov_editor');
   $role->grantPermission('access publication views');
   $role->save();
 

--- a/localgov_publications.install
+++ b/localgov_publications.install
@@ -123,25 +123,23 @@ function localgov_publications_update_10002() {
  * Grant 'access publication views' permission to Editor and apply as an access
  * condition to the publication view.
  */
-function localgov_publications_update_10003($is_syncing) {
-  if (!$is_syncing) {
-    // Make sure Editors have the new View permission.
-    $entity_type_manager = Drupal::service('entity_type.manager');
-    $role = $entity_type_manager->getStorage('user_role')->load('localgov_editor');
-    $role->grantPermission('access publication views');
-    $role->save();
+function localgov_publications_update_10003() {
+  // Make sure Editors have the new View permission.
+  $entity_type_manager = \Drupal::service('entity_type.manager');
+  $role = $entity_type_manager->getStorage('user_role')->load('localgov_editor');
+  $role->grantPermission('access publication views');
+  $role->save();
 
-    // Check if the view needs updating to use new permission.
-    $config_factory = Drupal::service('config.factory');
-    if ($editable = $config_factory->getEditable('views.view.publications')) {
-      $display = $editable->get('display');
-      if (isset($display['default']['display_options']['access'])) {
-        $access = $display['default']['display_options']['access'];
-        // Only update if the defaults haven't been changed.
-        if ($access['type'] == 'perm' && $access['options']['perm'] == 'access content') {
-          $display['default']['display_options']['access']['options']['perm'] = 'access publication views';
-          $editable->set('display', $display)->save();
-        }
+  // Check if the view needs updating to use new permission.
+  $config_factory = \Drupal::service('config.factory');
+  if ($editable = $config_factory->getEditable('views.view.publications')) {
+    $display = $editable->get('display');
+    if (isset($display['default']['display_options']['access'])) {
+      $access = $display['default']['display_options']['access'];
+      // Only update if the defaults haven't been changed.
+      if ($access['type'] == 'perm' && $access['options']['perm'] == 'access content') {
+        $display['default']['display_options']['access']['options']['perm'] = 'access publication views';
+        $editable->set('display', $display)->save();
       }
     }
   }

--- a/localgov_publications.install
+++ b/localgov_publications.install
@@ -7,6 +7,8 @@
 
 use Drupal\filter\Entity\FilterFormat;
 use Drupal\filter\FilterFormatInterface;
+use Drupal\user\RoleInterface;
+use Drupal\views\ViewEntityInterface;
 
 /**
  * Implements hook_install().
@@ -75,7 +77,7 @@ function localgov_publications_install_filter(): void {
  * Remove references to the book content type from the key value store that are
  * left over after book's config is removed.
  */
-function localgov_publications_update_10001() {
+function localgov_publications_update_10001(): void {
 
   // If the book content type is still installed in the site, don't do anything.
   $entityTypeManager = \Drupal::service('entity_type.manager');
@@ -98,7 +100,7 @@ function localgov_publications_update_10001() {
 /**
  * Set up the new localgov-publication-path token on existing installations.
  */
-function localgov_publications_update_10002() {
+function localgov_publications_update_10002(): void {
 
   // Add our new token into pathauto's list of safe tokens.
   $config = \Drupal::configFactory()->getEditable('pathauto.settings');
@@ -118,29 +120,41 @@ function localgov_publications_update_10002() {
 }
 
 /**
- * Expanding Publications permissions.
- *
- * Grant 'access publication views' permission to Editor and apply as an access
- * condition to the publication view.
+ * Grant new 'access publication views' permission to localgov_editor role.
  */
-function localgov_publications_update_10003() {
+function localgov_publications_update_10003(): void {
   // Make sure Editors have the new View permission.
-  $entity_type_manager = \Drupal::service('entity_type.manager');
-  $role = $entity_type_manager->getStorage('user_role')->load('localgov_editor');
-  $role->grantPermission('access publication views');
-  $role->save();
+  $role = \Drupal::service('entity_type.manager')
+    ->getStorage('user_role')
+    ->load('localgov_editor');
 
-  // Check if the view needs updating to use new permission.
-  $config_factory = \Drupal::service('config.factory');
-  if ($editable = $config_factory->getEditable('views.view.publications')) {
-    $display = $editable->get('display');
-    if (isset($display['default']['display_options']['access'])) {
-      $access = $display['default']['display_options']['access'];
-      // Only update if the defaults haven't been changed.
-      if ($access['type'] == 'perm' && $access['options']['perm'] == 'access content') {
-        $display['default']['display_options']['access']['options']['perm'] = 'access publication views';
-        $editable->set('display', $display)->save();
-      }
+  if ($role instanceof RoleInterface) {
+    $role->grantPermission('access publication views');
+    $role->save();
+  }
+}
+
+/**
+ * Use 'access publication views' permission for the publication view.
+ */
+function localgov_publications_update_10004(): void {
+
+  /** @var ?\Drupal\views\ViewEntityInterface $publicationsView */
+  $publicationsView = \Drupal::service('entity_type.manager')
+    ->getStorage('view')
+    ->load('publications');
+
+  if (!$publicationsView instanceof ViewEntityInterface) {
+    return;
+  }
+
+  $display = $publicationsView->get('display');
+  if (isset($display['default']['display_options']['access'])) {
+    $access = $display['default']['display_options']['access'];
+    // Only update if the defaults haven't been changed.
+    if ($access['type'] === 'perm' && $access['options']['perm'] === 'access content') {
+      $display['default']['display_options']['access']['options']['perm'] = 'access publication views';
+      $publicationsView->set('display', $display)->save();
     }
   }
 }

--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -57,6 +57,7 @@ function localgov_publications_theme($existing, $type, $theme, $path): array {
 function localgov_publications_localgov_roles_default(): array {
   return [
     RolesHelper::EDITOR_ROLE => [
+      'access publication views',
       'add content to books',
       'administer book outlines',
       'create new books',

--- a/localgov_publications.permissions.yml
+++ b/localgov_publications.permissions.yml
@@ -1,0 +1,3 @@
+access publication views:
+  title: 'View lists of publications content'
+  description: 'View administrative lists of nodes of type publication'


### PR DESCRIPTION
Define a new permission for viewing admin lists of publications. Apply this permission to the Editor role and, if the permissions of the view have not been changed, the Publication view.