### PR TITLE
Fix/1.x/166 link icons to content

### DIFF
--- a/templates/media--document--publication.html.twig
+++ b/templates/media--document--publication.html.twig
@@ -44,11 +44,15 @@
   {{ title_suffix.contextual_links }}
   {% set file_uri = content.field_media_document[0]['#file'].uri.value %}
   {% set file_href = file_url(file_uri) %}
-  <a href="{{ file_href }}">
+  {% if file_href is not empty %}
+    <a href="{{ file_href }}">
+  {% endif %}
     <svg class="publication-document__thumbnail-image publication-document__thumbnail-image--document" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
       <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"></path>
     </svg>
-  </a>
+  {% if file_href is not empty %}
+    </a>
+  {% endif %}
   <div>
     {{ content }}
     <p>{{ 'This file may not be suitable for users of assistive technology.'|t }}</p>

--- a/templates/media--document--publication.html.twig
+++ b/templates/media--document--publication.html.twig
@@ -42,9 +42,13 @@
 
 <div{{ attributes.addClass(classes) }}>
   {{ title_suffix.contextual_links }}
-  <svg class="publication-document__thumbnail-image publication-document__thumbnail-image--document" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
-    <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"></path>
-  </svg>
+  {% set file_uri = content.field_media_document[0]['#file'].uri.value %}
+  {% set file_href = file_url(file_uri) %}
+  <a href="{{ file_href }}">
+    <svg class="publication-document__thumbnail-image publication-document__thumbnail-image--document" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+      <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"></path>
+    </svg>
+  </a>
   <div>
     {{ content }}
     <p>{{ 'This file may not be suitable for users of assistive technology.'|t }}</p>

--- a/templates/publication-html-reference.html.twig
+++ b/templates/publication-html-reference.html.twig
@@ -61,16 +61,18 @@
       {% for item in items %}
         <div{{ attributes.addClass(classes, 'publication-document', 'publication-document--html') }}>
           {{ title_suffix.contextual_links }}
-          {% if item.content['#url'].external %}
-            {% set svg_href = item.content['#url'].uri %}
-          {% else %}
+          {% if item.content['#url'] is not null %}
             {% set svg_href = path(item.content['#url'].routeName, item.content['#url'].routeParameters) %}
           {% endif %}
-          <a href="{{ svg_href }}">
+          {% if svg_href is not null %}
+            <a href="{{ svg_href }}">
+          {% endif %}
             <svg class="publication-document__thumbnail-image publication-document__thumbnail-image--html" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
               <path d="M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z" stroke-width="0"></path>
             </svg>
-          </a>
+          {% if svg_href is not null %}
+            </a>
+          {% endif %}
           <div>
             {{ item.content }}
             <p>{{ 'HTML'|t }}</p>

--- a/templates/publication-html-reference.html.twig
+++ b/templates/publication-html-reference.html.twig
@@ -61,9 +61,16 @@
       {% for item in items %}
         <div{{ attributes.addClass(classes, 'publication-document', 'publication-document--html') }}>
           {{ title_suffix.contextual_links }}
-          <svg class="publication-document__thumbnail-image publication-document__thumbnail-image--html" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
-            <path d="M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z" stroke-width="0"></path>
-          </svg>
+          {% if item.content['#url'].external %}
+            {% set svg_href = item.content['#url'].uri %}
+          {% else %}
+            {% set svg_href = path(item.content['#url'].routeName, item.content['#url'].routeParameters) %}
+          {% endif %}
+          <a href="{{ svg_href }}">
+            <svg class="publication-document__thumbnail-image publication-document__thumbnail-image--html" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="true">
+              <path d="M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z" stroke-width="0"></path>
+            </svg>
+          </a>
           <div>
             {{ item.content }}
             <p>{{ 'HTML'|t }}</p>


### PR DESCRIPTION
On a cover page, if we can turn node and media entities into URLs, link the SVG icons to those URLs.