### PR TITLE
fix: drupal 11 support

### DIFF
--- a/config/install/views.view.publications_banner.yml
+++ b/config/install/views.view.publications_banner.yml
@@ -147,7 +147,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/src/Breadcrumb/BreadcrumbBuilder.php
+++ b/src/Breadcrumb/BreadcrumbBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\localgov_publications\Breadcrumb;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\NodeInterface;
 use Drupal\system\PathBasedBreadcrumbBuilder;
@@ -21,7 +22,7 @@ class BreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
   /**
    * {@inheritdoc}
    */
-  public function applies(RouteMatchInterface $route_match) {
+  public function applies(RouteMatchInterface $route_match, ?CacheableMetadata $cacheable_metadata = NULL) {
     $node = $route_match->getParameter('node');
     return $node instanceof NodeInterface && localgov_publications_is_publication_type($node->getType());
   }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes some errors around recent Drupal 10 and 11 changes.

1. Support from all Views contextual filter settings for the default_argument_skip_url setting is removed from drupal:11.0.0. No replacement is provided. See https://www.drupal.org/node/3382316
2. Core BreadcrumbBuilder changes introduced in Drupal 10.4 and Drupal 11 (see https://www.drupal.org/project/drupal/issues/2719721) the way in this PR should maintain compatibility from 10.2+ and fix WSOD in Drupal 11