### PR TITLE
Split books and publications in the node book select widget

### DIFF
--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -224,7 +224,7 @@ function localgov_publications_form_alter(&$form, FormStateInterface $form_state
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
   $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
   $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
-    return (in_array($option, $valid_bids) || $option == 0 || !is_numeric($option));
+    return (in_array($option, $valid_bids, TRUE) || $option == 0 || !is_numeric($option));
   }, ARRAY_FILTER_USE_KEY);
 
 }
@@ -257,7 +257,7 @@ function localgov_publications_form_node_form_alter(&$form, FormStateInterface $
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
   $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
   $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
-    return (!in_array($option, $valid_bids) || $option == 0 || !is_numeric($option));
+    return (!in_array($option, $valid_bids, TRUE) || $option == 0 || !is_numeric($option));
   }, ARRAY_FILTER_USE_KEY);
 
 }

--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -221,6 +221,13 @@ function _localgov_publications_node_form_alter(array &$form, FormStateInterface
     if (isset($form['book']['bid']['#options']['new'])) {
       $form['book']['bid']['#options']['new'] = localgov_publications_book_to_publication($form['book']['bid']['#options']['new']);
     }
+
+    // New book will be the node ID oin the edit page.
+    $nid = $form_state->getFormObject()->getEntity()->id();
+    if (isset($form['book']['bid']['#options'][$nid])) {
+      $form['book']['bid']['#options'][$nid] = localgov_publications_book_to_publication($form['book']['bid']['#options'][$nid]);
+    }
+
     if (isset($form['book']['pid']['#prefix'])) {
       $form['book']['pid']['#prefix'] = localgov_publications_book_to_publication($form['book']['pid']['#prefix']);
     }

--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -222,7 +222,7 @@ function _localgov_publications_node_form_alter(array &$form, FormStateInterface
       $form['book']['bid']['#options']['new'] = localgov_publications_book_to_publication($form['book']['bid']['#options']['new']);
     }
 
-    // New book will be the node ID oin the edit page.
+    // New book will be the node ID on the edit page.
     $nid = $form_state->getFormObject()->getEntity()->id();
     if (isset($form['book']['bid']['#options'][$nid])) {
       $form['book']['bid']['#options'][$nid] = localgov_publications_book_to_publication($form['book']['bid']['#options'][$nid]);
@@ -268,7 +268,7 @@ function _localgov_publications_node_form_alter(array &$form, FormStateInterface
  * @return array
  *   Array of top level book page node ids, converted to integers.
  */
-function _localgov_publications_valid_bids(array $bids) :array {
+function _localgov_publications_valid_bids(array $bids): array {
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
   $valid_bids = $node_storage->getQuery()
     ->condition('type', 'localgov_publication_page')

--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -216,6 +216,57 @@ function localgov_publications_form_alter(&$form, FormStateInterface $form_state
   if (isset($form['book']['pid']['#description'])) {
     $form['book']['pid']['#description'] = localgov_publications_book_to_publication($form['book']['pid']['#description']);
   }
+
+  $bids = array_filter(array_keys($form['book']['bid']['#options']), function ($item) {
+    return (is_numeric($item) && $item != 0);
+  });
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
+  $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
+    return (in_array($option, $valid_bids) || $option == 0 || !is_numeric($option));
+  }, ARRAY_FILTER_USE_KEY);
+
+}
+
+/**
+ * Implements hook_form_BASE_ID_alter().
+ */
+function localgov_publications_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
+
+  // If this form element isn't present there's nothing for us to do here.
+  if (!isset($form['book'])) {
+    return;
+  }
+
+  $publication_node_forms = [
+    'node_localgov_publication_page_form',
+    'node_localgov_publication_page_edit_form',
+  ];
+
+  // Publications alter logic goes here.
+  if (in_array($form_id, $publication_node_forms, TRUE)) {
+    return;
+  }
+
+  // Else, strip out publications from any books.
+  $bids = array_filter(array_keys($form['book']['bid']['#options']), function ($item) {
+    return (is_numeric($item) && $item != 0);
+  });
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
+  $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
+    return (!in_array($option, $valid_bids) || $option == 0 || !is_numeric($option));
+  }, ARRAY_FILTER_USE_KEY);
+
+}
+
+/**
+ * Implements hook_form_BASE_ID_alter().
+ */
+function localgov_publications_form_node_edit_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
+  localgov_publications_form_node_form_alter($form, $form_state, $form_id);
 }
 
 /**

--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -176,63 +176,21 @@ function localgov_publications_book_to_publication(TranslatableMarkup|string $or
 }
 
 /**
- * Implements hook_form_alter().
+ * Alter the node forms (add and edit)
+ *
+ * This function is called from both
+ *   localgov_publications_form_node_form_alter (/node/add)
+ * and
+ *   localgov_publications_form_node_edit_form_alter (/node/x/edit)
+ *
+ * @param array $form
+ *   Form elements.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state object.
+ * @param string $form_id
+ *   Form ID string.
  */
-function localgov_publications_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
-
-  $forms_to_alter = [
-    'node_localgov_publication_page_form',
-    'node_localgov_publication_page_edit_form',
-  ];
-
-  if (!in_array($form_id, $forms_to_alter, TRUE)) {
-    return;
-  }
-
-  // If this form element isn't present there's nothing for us to do here.
-  if (!isset($form['book'])) {
-    return;
-  }
-
-  // Attach JS.
-  if ($form['book']['#attached']['library'][0] == 'book/drupal.book') {
-    $form['book']['#attached']['library'][0] = 'localgov_publications/localgov-publications';
-  }
-
-  // Attach our validation.
-  $form['#validate'][] = 'localgov_publications_validate_node_form';
-
-  // All these places in the form contain the word 'book'.
-  // We want them to say 'publication' instead.
-  $form['book']['#title'] = localgov_publications_book_to_publication($form['book']['#title']);
-  $form['book']['bid']['#title'] = localgov_publications_book_to_publication($form['book']['bid']['#title']);
-  $form['book']['bid']['#description'] = localgov_publications_book_to_publication($form['book']['bid']['#description']);
-  if (isset($form['book']['bid']['#options']['new'])) {
-    $form['book']['bid']['#options']['new'] = localgov_publications_book_to_publication($form['book']['bid']['#options']['new']);
-  }
-  if (isset($form['book']['pid']['#prefix'])) {
-    $form['book']['pid']['#prefix'] = localgov_publications_book_to_publication($form['book']['pid']['#prefix']);
-  }
-  if (isset($form['book']['pid']['#description'])) {
-    $form['book']['pid']['#description'] = localgov_publications_book_to_publication($form['book']['pid']['#description']);
-  }
-
-  $bids = array_filter(array_keys($form['book']['bid']['#options']), function ($item) {
-    return (is_numeric($item) && $item != 0);
-  });
-
-  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-  $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
-  $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
-    return (in_array($option, $valid_bids, TRUE) || $option == 0 || !is_numeric($option));
-  }, ARRAY_FILTER_USE_KEY);
-
-}
-
-/**
- * Implements hook_form_BASE_ID_alter().
- */
-function localgov_publications_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
+function _localgov_publications_node_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
 
   // If this form element isn't present there's nothing for us to do here.
   if (!isset($form['book'])) {
@@ -244,29 +202,76 @@ function localgov_publications_form_node_form_alter(&$form, FormStateInterface $
     'node_localgov_publication_page_edit_form',
   ];
 
-  // Publications alter logic goes here.
+  // Alter the publications node forms.
   if (in_array($form_id, $publication_node_forms, TRUE)) {
-    return;
+
+    // Attach JS.
+    if ($form['book']['#attached']['library'][0] == 'book/drupal.book') {
+      $form['book']['#attached']['library'][0] = 'localgov_publications/localgov-publications';
+    }
+
+    // Attach our validation.
+    $form['#validate'][] = 'localgov_publications_validate_node_form';
+
+    // All these places in the form contain the word 'book'.
+    // We want them to say 'publication' instead.
+    $form['book']['#title'] = localgov_publications_book_to_publication($form['book']['#title']);
+    $form['book']['bid']['#title'] = localgov_publications_book_to_publication($form['book']['bid']['#title']);
+    $form['book']['bid']['#description'] = localgov_publications_book_to_publication($form['book']['bid']['#description']);
+    if (isset($form['book']['bid']['#options']['new'])) {
+      $form['book']['bid']['#options']['new'] = localgov_publications_book_to_publication($form['book']['bid']['#options']['new']);
+    }
+    if (isset($form['book']['pid']['#prefix'])) {
+      $form['book']['pid']['#prefix'] = localgov_publications_book_to_publication($form['book']['pid']['#prefix']);
+    }
+    if (isset($form['book']['pid']['#description'])) {
+      $form['book']['pid']['#description'] = localgov_publications_book_to_publication($form['book']['pid']['#description']);
+    }
+
+    $bids = array_filter(array_keys($form['book']['bid']['#options']), function ($item) {
+      return (is_numeric($item) && $item != 0);
+    });
+
+    // Filter non publications from book selector.
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
+    $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
+
+      // Use non strict type check because $option will be int and $valid_bids
+      // will contrain strings.
+      return (in_array($option, $valid_bids, FALSE) || $option == 0 || !is_numeric($option));
+    }, ARRAY_FILTER_USE_KEY);
   }
 
   // Else, strip out publications from any books.
-  $bids = array_filter(array_keys($form['book']['bid']['#options']), function ($item) {
-    return (is_numeric($item) && $item != 0);
-  });
+  else {
+    $bids = array_filter(array_keys($form['book']['bid']['#options']), function ($item) {
+      return (is_numeric($item) && $item != 0);
+    });
 
-  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-  $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
-  $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
-    return (!in_array($option, $valid_bids, TRUE) || $option == 0 || !is_numeric($option));
-  }, ARRAY_FILTER_USE_KEY);
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
+    $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
 
+      // Use non strict type check because $option will be int and $valid_bids
+      // will contrain strings.
+      return (!in_array($option, $valid_bids, FALSE) || $option == 0 || !is_numeric($option));
+    }, ARRAY_FILTER_USE_KEY);
+  }
+}
+
+/**
+ * Implements hook_form_BASE_ID_alter().
+ */
+function localgov_publications_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
+  _localgov_publications_node_form_alter($form, $form_state, $form_id);
 }
 
 /**
  * Implements hook_form_BASE_ID_alter().
  */
 function localgov_publications_form_node_edit_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
-  localgov_publications_form_node_form_alter($form, $form_state, $form_id);
+  _localgov_publications_node_form_alter($form, $form_state, $form_id);
 }
 
 /**

--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -233,13 +233,9 @@ function _localgov_publications_node_form_alter(array &$form, FormStateInterface
     });
 
     // Filter non publications from book selector.
-    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-    $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
+    $valid_bids = _localgov_publications_valid_bids($bids);
     $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
-
-      // Use non strict type check because $option will be int and $valid_bids
-      // will contrain strings.
-      return (in_array($option, $valid_bids, FALSE) || $option == 0 || !is_numeric($option));
+      return (in_array($option, $valid_bids, TRUE) || $option == 0 || !is_numeric($option));
     }, ARRAY_FILTER_USE_KEY);
   }
 
@@ -249,15 +245,33 @@ function _localgov_publications_node_form_alter(array &$form, FormStateInterface
       return (is_numeric($item) && $item != 0);
     });
 
-    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-    $valid_bids = $node_storage->getQuery()->condition('type', 'localgov_publication_page')->condition('nid', $bids, 'IN')->accessCheck(TRUE)->execute();
+    $valid_bids = _localgov_publications_valid_bids($bids);
     $form['book']['bid']['#options'] = array_filter($form['book']['bid']['#options'], function ($option) use ($valid_bids) {
-
-      // Use non strict type check because $option will be int and $valid_bids
-      // will contrain strings.
-      return (!in_array($option, $valid_bids, FALSE) || $option == 0 || !is_numeric($option));
+      return (!in_array($option, $valid_bids, TRUE) || $option == 0 || !is_numeric($option));
     }, ARRAY_FILTER_USE_KEY);
   }
+}
+
+/**
+ * Get valid publication book bids.
+ *
+ * @param array $bids
+ *   Book ids on the node edit form.
+ *
+ * @return array
+ *   Array of top level book page node ids, converted to integers.
+ */
+function _localgov_publications_valid_bids(array $bids) :array {
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $valid_bids = $node_storage->getQuery()
+    ->condition('type', 'localgov_publication_page')
+    ->condition('nid', $bids, 'IN')
+    ->accessCheck(TRUE)
+    ->execute();
+
+  // Convert arrray to integers for comparision with option values.
+  $valid_bids = array_map(fn($valid_bid) => (int) $valid_bid, $valid_bids);
+  return $valid_bids;
 }
 
 /**

--- a/src/Plugin/Block/TocBlock.php
+++ b/src/Plugin/Block/TocBlock.php
@@ -78,6 +78,11 @@ class TocBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
     /** @var \Drupal\node\NodeInterface $node */
     $node = $this->getContextValue('node');
+
+    // Don't render on new nodes (/node/add form).
+    if ($node->isNew()) {
+      return [];
+    }
     $build = $this->entityTypeManager->getViewBuilder('node')->view($node, 'full');
 
     // Call this so the render we're about to do has the same IDs as the page.

--- a/tests/src/Functional/PublicationBookSplitTest.php
+++ b/tests/src/Functional/PublicationBookSplitTest.php
@@ -90,7 +90,7 @@ class PublicationBookSplitTest extends BrowserTestBase {
 
     $this->assertEquals($expected, $options);
 
-    // // Create a book node and check publications are filtered.
+    // Create a book node and check publications are filtered.
     $this->drupalGet('/node/add/book');
 
     // Get the book select widget.
@@ -107,6 +107,55 @@ class PublicationBookSplitTest extends BrowserTestBase {
     ];
 
     $this->assertEquals($expected, $options);
+
+    // Test filters apply to edit pages.
+    $publication_node_2 = $this->createNode([
+      'type' => 'localgov_publication_page',
+      'title' => 'Test publication page 2',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->drupalGet($publication_node_2->toUrl('edit-form')->toString());
+
+    // Get the book select widget.
+    $query = $this->xpath('.//select[@name="book[bid]"]//option');
+    $options = [];
+    foreach ($query as $option) {
+      $options[$option->getAttribute('value')] = $option->getText();
+    }
+
+    $expected = [
+      0 => '- None -',
+      $publication_node_2->id() => '- Create a new publication -',
+      $publication_node->id() => 'Test publication page',
+    ];
+
+    $this->assertEquals($expected, $options);
+
+    // Book node edit page.
+    $book_node_2 = $this->createNode([
+      'type' => 'book',
+      'title' => 'Test book 2',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->drupalGet($book_node_2->toUrl('edit-form')->toString());
+
+    // Get the book select widget.
+    $query = $this->xpath('.//select[@name="book[bid]"]//option');
+    $options = [];
+    foreach ($query as $option) {
+      $options[$option->getAttribute('value')] = $option->getText();
+    }
+
+    $expected = [
+      0 => '- None -',
+      $book_node_2->id() => '- Create a new book -',
+      $book_node->id() => 'Test book',
+    ];
+
+    $this->assertEquals($expected, $options);
+
   }
 
 }

--- a/tests/src/Functional/PublicationBookSplitTest.php
+++ b/tests/src/Functional/PublicationBookSplitTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\Tests\localgov_publications\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+
+/**
+ * Tests LocalGov Publications books are split from Drupal books.
+ *
+ * @group localgov_publications
+ */
+class PublicationBookSplitTest extends BrowserTestBase {
+
+  use ContentTypeCreationTrait;
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'layout_paragraphs',
+    'localgov_publications',
+  ];
+
+  /**
+   * Test the book selection dropdown filters books and publications.
+   *
+   * This is so that publication pages can only be in publications, and other
+   * Drupal books do not contain publication pages.
+   */
+  public function testNodeBookSelectorFiltersBooks() :void {
+
+    // Set up a publications node.
+    $publication_node = $this->createNode([
+      'type' => 'localgov_publication_page',
+      'title' => 'Test publication page',
+      'status' => NodeInterface::PUBLISHED,
+      'book' => [
+        'bid' => 'new',
+      ],
+    ]);
+
+    // Set up a standard book node.
+    $this->createContentType([
+      'type' => 'book',
+    ]);
+    $book_node = $this->createNode([
+      'type' => 'book',
+      'title' => 'Test book',
+      'status' => NodeInterface::PUBLISHED,
+      'book' => [
+        'bid' => 'new',
+      ],
+    ]);
+
+    // Set up a book administrator.
+    $bookAdministrator = $this->createUser([
+      'administer book outlines',
+      'bypass node access',
+      'administer nodes',
+      'create new books',
+      'add content to books',
+    ]);
+    $this->drupalLogin($bookAdministrator);
+
+    // Create a publication node and check books are filtered.
+    $this->drupalGet('/node/add/localgov_publication_page');
+
+    // Get the book select widget.
+    $query = $this->xpath('.//select[@name="book[bid]"]//option');
+    $options = [];
+    foreach ($query as $option) {
+      $options[$option->getAttribute('value')] = $option->getText();
+    }
+
+    $expected = [
+      0 => '- None -',
+      'new' => '- Create a new publication -',
+      $publication_node->id() => 'Test publication page',
+    ];
+
+    $this->assertEquals($expected, $options);
+
+    // // Create a book node and check publications are filtered.
+    $this->drupalGet('/node/add/book');
+
+    // Get the book select widget.
+    $query = $this->xpath('.//select[@name="book[bid]"]//option');
+    $options = [];
+    foreach ($query as $option) {
+      $options[$option->getAttribute('value')] = $option->getText();
+    }
+
+    $expected = [
+      0 => '- None -',
+      'new' => '- Create a new book -',
+      $book_node->id() => 'Test book',
+    ];
+
+    $this->assertEquals($expected, $options);
+  }
+
+}

--- a/tests/src/Functional/TocBlockTest.php
+++ b/tests/src/Functional/TocBlockTest.php
@@ -6,6 +6,7 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Functional tests for the TocBlock.
@@ -87,6 +88,24 @@ class TocBlockTest extends BrowserTestBase {
     foreach ($expectedIDs as $expectedID) {
       $this->assertSession()->responseContains($expectedID);
     }
+  }
+
+  /**
+   * Test the TOC block does not interfere with the create publication page.
+   */
+  public function testTocBlockIsNotDisplayedOnNodeAddPage() :void {
+
+    $user = $this->createUser([
+      'bypass node access',
+    ]);
+    $this->drupalLogin($user);
+
+    $this->drupalGet('/node/add/localgov_publication_page');
+    $this->assertSession()->responseNotContains('On this page');
+
+    // Test node/add/localgov_publication_page still functions.
+    // @See https://github.com/localgovdrupal/localgov_publications/issues/230
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
   }
 
 }


### PR DESCRIPTION
Fix #229 
Fix #230

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?
- Remove non pub books from pub selector and pubs from book selector on node forms
- Fix bug with TOC block that was preventing book split test working

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Create a content types that can go in a book along with a publication.
Create a book of each type.
When adding a new publication page, the book node should not appear in the publication outline widget.
Same for when adding a new book page (Publication is not in the book outline widget).

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Drupal standard books and Publications can live side by side.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Some people may be mixing them?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->
<img width="322" alt="Screenshot 2025-02-17 at 3 51 40 pm" src="https://github.com/user-attachments/assets/efde0c9d-10c5-4ee9-a769-5f1e6e788ac0" />



## Accessibility
n/a