### PR TITLE
Only search for valid book ids if there are existing books

### DIFF
--- a/localgov_publications.module
+++ b/localgov_publications.module
@@ -268,16 +268,21 @@ function _localgov_publications_node_form_alter(array &$form, FormStateInterface
  * @return array
  *   Array of top level book page node ids, converted to integers.
  */
-function _localgov_publications_valid_bids(array $bids): array {
-  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-  $valid_bids = $node_storage->getQuery()
-    ->condition('type', 'localgov_publication_page')
-    ->condition('nid', $bids, 'IN')
-    ->accessCheck(TRUE)
-    ->execute();
+function _localgov_publications_valid_bids(array $bids) :array {
+  $valid_bids = [];
 
-  // Convert arrray to integers for comparision with option values.
-  $valid_bids = array_map(fn($valid_bid) => (int) $valid_bid, $valid_bids);
+  // Only search for valid books if $bids has values.
+  if (count($bids) !== 0) {
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $valid_bids = $node_storage->getQuery()
+      ->condition('type', 'localgov_publication_page')
+      ->condition('nid', $bids, 'IN')
+      ->accessCheck(TRUE)
+      ->execute();
+
+    // Convert arrray to integers for comparision with option values.
+    $valid_bids = array_map(fn($valid_bid) => (int) $valid_bid, $valid_bids);
+  }
   return $valid_bids;
 }
 

--- a/tests/src/Functional/PublicationBookSplitTest.php
+++ b/tests/src/Functional/PublicationBookSplitTest.php
@@ -6,6 +6,7 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Tests LocalGov Publications books are split from Drupal books.
@@ -30,6 +31,24 @@ class PublicationBookSplitTest extends BrowserTestBase {
     'layout_paragraphs',
     'localgov_publications',
   ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() :void {
+    parent::setUp();
+
+    // Set up a book administrator.
+    $bookAdministrator = $this->createUser([
+      'administer book outlines',
+      'bypass node access',
+      'administer nodes',
+      'create new books',
+      'add content to books',
+    ]);
+
+    $this->drupalLogin($bookAdministrator);
+  }
 
   /**
    * Test the book selection dropdown filters books and publications.
@@ -61,16 +80,6 @@ class PublicationBookSplitTest extends BrowserTestBase {
         'bid' => 'new',
       ],
     ]);
-
-    // Set up a book administrator.
-    $bookAdministrator = $this->createUser([
-      'administer book outlines',
-      'bypass node access',
-      'administer nodes',
-      'create new books',
-      'add content to books',
-    ]);
-    $this->drupalLogin($bookAdministrator);
 
     // Create a publication node and check books are filtered.
     $this->drupalGet('/node/add/localgov_publication_page');
@@ -156,6 +165,19 @@ class PublicationBookSplitTest extends BrowserTestBase {
 
     $this->assertEquals($expected, $options);
 
+  }
+
+  /**
+   * Test that publication pages can be created when there are no books.
+   */
+  public function testPublicationNodeAddPageWithoutExistingBooks() :void {
+
+    // Go to publication page.
+    $this->drupalGet('/node/add/localgov_publication_page');
+
+    // Test /node/add/localgov_publication_page is able to be displayed.
+    // @See https://github.com/localgovdrupal/localgov_publications/issues/236
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
   }
 
 }


### PR DESCRIPTION
Fix #236

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

On first install they will be no books, so there won't be any to check if they are valid causing a WSOD unless logging in as admin. Fix is to check there are book ids being passed into the valid_bids function.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

On a fresh install (without localgov_demo)
- Create a user with the editor user role
- Log in as the editor
- Try to create a new publication at /node/add/localgov_publication_page

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Edit screen should display, no WSOD.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

n/a

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->