### PR TITLE
Fix Deprecated PHP warning when no id fragment is present

### DIFF
--- a/src/Service/HeadingFinder.php
+++ b/src/Service/HeadingFinder.php
@@ -35,7 +35,7 @@ class HeadingFinder implements HeadingFinderInterface {
     foreach ($headings as $heading) {
       $attributes = explode(' ', $heading['attributes']);
 
-      $fragment = NULL;
+      $fragment = '';
 
       // Find the id attribute if there is one.
       foreach ($attributes as $attribute) {


### PR DESCRIPTION
Fix #240

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Change the default of the fragment when not present to an empty string instead of NULL.
<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Add a `<h2>` to a publication without a fragment and load the publication. We have a dedicated heading paragraph type that can do this. 
  

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

There should be no PHP deprecation warning.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

n/a
<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->
