### PR TITLE
Issue #243: Add the Summary field to the Publication content types

### DIFF
--- a/config/install/core.entity_form_display.node.localgov_publication_cover_page.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_publication_cover_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.localgov_publication_cover_page.localgov_publication
     - field.field.node.localgov_publication_cover_page.localgov_publication_content
     - field.field.node.localgov_publication_cover_page.localgov_publications_banner
+    - field.field.node.localgov_publication_cover_page.localgov_publication_summary
     - field.field.node.localgov_publication_cover_page.localgov_published_date
     - field.field.node.localgov_publication_cover_page.localgov_updated_date
     - node.type.localgov_publication_cover_page
@@ -16,6 +17,7 @@ dependencies:
     - media_library
     - paragraphs
     - path
+    - text
 third_party_settings:
   field_group:
     group_tabs:
@@ -37,6 +39,7 @@ third_party_settings:
     group_description:
       children:
         - title
+        - localgov_publication_summary
         - localgov_publication_content
         - localgov_published_date
         - localgov_updated_date
@@ -138,6 +141,14 @@ content:
     weight: 4
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_publication_summary:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   localgov_updated_date:
     type: datetime_default

--- a/config/install/core.entity_form_display.node.localgov_publication_page.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_publication_page.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_publication_page.localgov_publication_content
+    - field.field.node.localgov_publication_page.localgov_publication_summary
     - field.field.node.localgov_publication_page.localgov_published_date
     - field.field.node.localgov_publication_page.localgov_updated_date
     - node.type.localgov_publication_page
@@ -10,6 +11,7 @@ dependencies:
     - datetime
     - layout_paragraphs
     - path
+    - text
 id: node.localgov_publication_page.default
 targetEntityType: node
 bundle: localgov_publication_page
@@ -17,13 +19,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   localgov_publication_content:
     type: layout_paragraphs
-    weight: 3
+    weight: 4
     region: content
     settings:
       preview_view_mode: default
@@ -36,6 +38,14 @@ content:
     weight: 9
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_publication_summary:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   localgov_updated_date:
     type: datetime_default
@@ -80,7 +90,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 1
+    weight: 2
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/install/core.entity_view_display.node.localgov_publication_cover_page.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_publication_cover_page.default.yml
@@ -6,12 +6,14 @@ dependencies:
     - field.field.node.localgov_publication_cover_page.localgov_publication
     - field.field.node.localgov_publication_cover_page.localgov_publication_content
     - field.field.node.localgov_publication_cover_page.localgov_publications_banner
+    - field.field.node.localgov_publication_cover_page.localgov_publication_summary
     - field.field.node.localgov_publication_cover_page.localgov_published_date
     - field.field.node.localgov_publication_cover_page.localgov_updated_date
     - node.type.localgov_publication_cover_page
   module:
     - entity_reference_revisions
     - field_group
+    - text
     - user
 third_party_settings:
   field_group:
@@ -75,6 +77,13 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 4
+    region: content
+  localgov_publication_summary:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
     region: content
 hidden:
   localgov_publications_banner: true

--- a/config/install/core.entity_view_display.node.localgov_publication_cover_page.full.yml
+++ b/config/install/core.entity_view_display.node.localgov_publication_cover_page.full.yml
@@ -7,11 +7,13 @@ dependencies:
     - field.field.node.localgov_publication_cover_page.localgov_publication
     - field.field.node.localgov_publication_cover_page.localgov_publication_content
     - field.field.node.localgov_publication_cover_page.localgov_publications_banner
+    - field.field.node.localgov_publication_cover_page.localgov_publication_summary
     - field.field.node.localgov_publication_cover_page.localgov_published_date
     - field.field.node.localgov_publication_cover_page.localgov_updated_date
     - node.type.localgov_publication_cover_page
   module:
     - field_group
+    - text
     - user
 third_party_settings:
   field_group:
@@ -66,6 +68,13 @@ content:
       link: true
     third_party_settings: {  }
     weight: 4
+    region: content
+  localgov_publication_summary:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   localgov_publication_content: true

--- a/config/install/core.entity_view_display.node.localgov_publication_cover_page.teaser.yml
+++ b/config/install/core.entity_view_display.node.localgov_publication_cover_page.teaser.yml
@@ -7,10 +7,12 @@ dependencies:
     - field.field.node.localgov_publication_cover_page.localgov_publication
     - field.field.node.localgov_publication_cover_page.localgov_publication_content
     - field.field.node.localgov_publication_cover_page.localgov_publications_banner
+    - field.field.node.localgov_publication_cover_page.localgov_publication_summary
     - field.field.node.localgov_publication_cover_page.localgov_published_date
     - field.field.node.localgov_publication_cover_page.localgov_updated_date
     - node.type.localgov_publication_cover_page
   module:
+    - text
     - user
 id: node.localgov_publication_cover_page.teaser
 targetEntityType: node
@@ -21,6 +23,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 100
+    region: content
+  localgov_publication_summary:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   localgov_documents: true

--- a/config/install/core.entity_view_display.node.localgov_publication_page.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_publication_page.default.yml
@@ -3,11 +3,13 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_publication_page.localgov_publication_content
+    - field.field.node.localgov_publication_page.localgov_publication_summary
     - field.field.node.localgov_publication_page.localgov_published_date
     - field.field.node.localgov_publication_page.localgov_updated_date
     - node.type.localgov_publication_page
   module:
     - layout_paragraphs
+    - text
     - user
 id: node.localgov_publication_page.default
 targetEntityType: node
@@ -29,5 +31,6 @@ content:
     weight: 0
     region: content
 hidden:
+  localgov_publication_summary: true
   localgov_published_date: true
   localgov_updated_date: true

--- a/config/install/core.entity_view_display.node.localgov_publication_page.teaser.yml
+++ b/config/install/core.entity_view_display.node.localgov_publication_page.teaser.yml
@@ -4,10 +4,12 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_publication_page.localgov_publication_content
+    - field.field.node.localgov_publication_page.localgov_publication_summary
     - field.field.node.localgov_publication_page.localgov_published_date
     - field.field.node.localgov_publication_page.localgov_updated_date
     - node.type.localgov_publication_page
   module:
+    - text
     - user
 id: node.localgov_publication_page.teaser
 targetEntityType: node
@@ -18,6 +20,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 100
+    region: content
+  localgov_publication_summary:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   localgov_publication_content: true

--- a/config/install/field.field.node.localgov_publication_cover_page.localgov_publication_summary.yml
+++ b/config/install/field.field.node.localgov_publication_cover_page.localgov_publication_summary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_publication_summary
+    - node.type.localgov_publication_cover_page
+  module:
+    - text
+id: node.localgov_publication_cover_page.localgov_publication_summary
+field_name: localgov_publication_summary
+entity_type: node
+bundle: localgov_publication_cover_page
+label: Summary
+description: 'A brief summary of this publication.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/install/field.field.node.localgov_publication_page.localgov_publication_summary.yml
+++ b/config/install/field.field.node.localgov_publication_page.localgov_publication_summary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_publication_summary
+    - node.type.localgov_publication_page
+  module:
+    - text
+id: node.localgov_publication_page.localgov_publication_summary
+field_name: localgov_publication_summary
+entity_type: node
+bundle: localgov_publication_page
+label: Summary
+description: 'A brief summary of this publication page.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/install/field.storage.node.localgov_publication_summary.yml
+++ b/config/install/field.storage.node.localgov_publication_summary.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+    - localgov_publications
+  enforced:
+    module:
+      - localgov_publications
+id: node.localgov_publication_summary
+field_name: localgov_publication_summary
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds a new _Summary_ text field to both _Publication page_ and _Publication cover page_ content types. This field allows editors to provide a brief summary of publications for display in teaser views, search results, and listing pages. Fixes #243.

  The Summary field (`localgov_publication_summary`) is:
  - A text_long field type (multi-line text without formatting)
  - Optional (not required)
  - Translatable
  - Displayed as a 5-row textarea in the edit form

  For _Publication page_ content type:
  - Added to form display after the title
  - Hidden in default view (shows full content instead)
  - Visible in teaser view for listings

  For _Publication cover page_ content type:
  - Added to the Content tab after the title
  - Visible in default, full, and teaser views
  - Displays before the main publication content


<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->